### PR TITLE
Fix TODO: Add newline at end of Docker polling

### DIFF
--- a/RaspberryPi/Scripts/Docker-clean.sh
+++ b/RaspberryPi/Scripts/Docker-clean.sh
@@ -62,7 +62,6 @@ EOF
 
 # On MacOS, restarting Docker Desktop for Mac might take a long time
 poll_for_docker_readiness() {
-  # TODO: add new line at the end of polling
   printf 'Waiting for docker engine to start:\n'
 
   local i=0
@@ -73,7 +72,7 @@ poll_for_docker_readiness() {
     tput el
   done
 
-  printf '\n'
+  printf '\n\n'
 }
 
 # Checks if a particular program is installed


### PR DESCRIPTION
Added an additional newline after the Docker engine polling completes for better visual separation in the output. This resolves the TODO comment in the poll_for_docker_readiness() function.