### PR TITLE
Implement TODO: Add yadm dotfiles initialization

### DIFF
--- a/Cachyos/Setup.sh
+++ b/Cachyos/Setup.sh
@@ -33,7 +33,8 @@ eval "$PKG" "$DOTFILES_TOOL"
 # --- CLONE DOTFILES & APPLY ---
 log "Cloning and applying dotfiles..."
 if [[ $DOTFILES_TOOL == "yadm" ]]; then
-  echo "TODO: yadm"
+  yadm clone "$DOTFILES_REPO"
+  yadm bootstrap 2>/dev/null || true  # Run bootstrap if it exists
 elif [[ $DOTFILES_TOOL == "chezmoi" ]]; then
   chezmoi init "$DOTFILES_REPO"
   chezmoi apply -v


### PR DESCRIPTION
- Replaced placeholder 'echo "TODO: yadm"' with proper yadm clone command
- Added yadm bootstrap call to run post-clone setup if bootstrap script exists
- Follows same pattern as chezmoi implementation