### PR TITLE
Remove privilege escalation functions and replace with sudo

### DIFF
--- a/Cachyos/Scripts/bench.sh
+++ b/Cachyos/Scripts/bench.sh
@@ -15,9 +15,6 @@ xecho(){ printf '%b
 log(){ xecho "$*"; }
 die(){ xecho "${RED}Error:${DEF} $*" >&2; exit 1; }
 confirm(){ local msg="$1"; printf '%s [y/N]: ' "$msg" >&2; read -r ans; [[ $ans == [Yy]* ]]; }
-get_priv_cmd(){ local cmd; for cmd in sudo-rs sudo doas; do if has "$cmd"; then printf '%s' "$cmd"; return 0; fi; done; [[ $EUID -eq 0 ]] || die "No privilege tool found and not running as root"; printf ''; }
-init_priv(){ local priv_cmd; priv_cmd=$(get_priv_cmd); [[ -n $priv_cmd && $EUID -ne 0 ]] && "$priv_cmd" -v; printf '%s' "$priv_cmd"; }
-run_priv(){ local priv_cmd="${PRIV_CMD:-}"; [[ -z $priv_cmd ]] && priv_cmd=$(get_priv_cmd); if [[ $EUID -eq 0 || -z $priv_cmd ]]; then "$@"; else "$priv_cmd" -- "$@"; fi; }
 print_banner(){ local banner="$1" title="${2:-}"; local flag_colors=("$LBLU" "$PNK" "$BWHT" "$PNK" "$LBLU"); local -a lines=(); while IFS= read -r line || [[ -n $line ]]; do lines+=("$line"); done <<<"$banner"; local line_count=${#lines[@]} segments=${#flag_colors[@]}; if ((line_count <= 1)); then printf '%s%s%s
 ' "${flag_colors[0]}" "${lines[0]}" "$DEF"; else for i in "${!lines[@]}"; do local segment_index=$((i * (segments - 1) / (line_count - 1))); ((segment_index >= segments)) && segment_index=$((segments - 1)); printf '%s%s%s
 ' "${flag_colors[segment_index]}" "${lines[i]}" "$DEF"; done; fi; [[ -n $title ]] && xecho "$title"; }
@@ -41,7 +38,7 @@ EOF
 }
 print_named_banner(){ local name="$1" title="${2:-Meow (> ^ <)}" banner; case "$name" in update) banner=$(get_update_banner) ;; clean) banner=$(get_clean_banner) ;; *) die "Unknown banner name: $name" ;; esac; print_banner "$banner" "$title"; }
 setup_build_env(){ [[ -r /etc/makepkg.conf ]] && source /etc/makepkg.conf &>/dev/null; export RUSTFLAGS="-Copt-level=3 -Ctarget-cpu=native -Ccodegen-units=1 -Cstrip=symbols"; export CFLAGS="-march=native -mtune=native -O3 -pipe"; export CXXFLAGS="$CFLAGS"; export LDFLAGS="-Wl,-O3 -Wl,--sort-common -Wl,--as-needed -Wl,-z,now -Wl,-z,pack-relative-relocs -Wl,-gc-sections"; export; export CARGO_CACHE_AUTO_CLEAN_FREQUENCY=always; export CARGO_HTTP_MULTIPLEXING=true CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_CACHE_RUSTC_INFO=1 RUSTC_BOOTSTRAP=1; local nproc_count; nproc_count=$(nproc 2>/dev/null || echo 4); export MAKEFLAGS="-j${nproc_count}"; export NINJAFLAGS="-j${nproc_count}"; if has clang && has clang++; then export CC=clang CXX=clang++ AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib; if has ld.lld; then export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"; fi; fi; has dbus-launch && eval "$(dbus-launch 2>/dev/null || :)"; }
-run_system_maintenance(){ local cmd=$1; shift; local args=("$@"); has "$cmd" || return 0; case "$cmd" in modprobed-db) "$cmd" store &>/dev/null || :;; hwclock | updatedb | chwd) run_priv "$cmd" "${args[@]}" &>/dev/null || :;; mandb) run_priv "$cmd" -q &>/dev/null || mandb -q &>/dev/null || :;; *) run_priv "$cmd" "${args[@]}" &>/dev/null || :;; esac; }
+run_system_maintenance(){ local cmd=$1; shift; local args=("$@"); has "$cmd" || return 0; case "$cmd" in modprobed-db) "$cmd" store &>/dev/null || :;; hwclock | updatedb | chwd) sudo "$cmd" "${args[@]}" &>/dev/null || :;; mandb) sudo "$cmd" -q &>/dev/null || mandb -q &>/dev/null || :;; *) sudo "$cmd" "${args[@]}" &>/dev/null || :;; esac; }
 capture_disk_usage(){ local var_name=$1; local -n ref="$var_name"; ref=$(df -h --output=used,pcent / 2>/dev/null | awk 'NR==2{print $1, $2}'); }
 find_files(){ if has fd; then fd -H "$@"; else find "$@"; fi; }
 find0(){ local root="$1"; shift; if has fdf; then fdf -H -0 "$@" . "$root"; elif has fd; then fd -H -0 "$@" . "$root"; else find "$root" "$@" -print0; fi; }
@@ -82,11 +79,11 @@ chrome_profiles(){ local root=$1 d; for d in "$root"/Default "$root"/"Profile "*
 ' "$d"; done; }
 _expand_wildcards(){ local path=$1; local -n result_ref=$2; if [[ $path == *\** ]]; then shopt -s nullglob; local -a items=($path); for item in "${items[@]}"; do [[ -e $item ]] && result_ref+=("$item"); done; shopt -u nullglob; else [[ -e $path ]] && result_ref+=("$path"); fi; }
 clean_paths(){ local paths=("$@") path; local existing_paths=(); for path in "${paths[@]}"; do _expand_wildcards "$path" existing_paths; done; [[ ${#existing_paths[@]} -gt 0 ]] && rm -rf --preserve-root -- "${existing_paths[@]}" &>/dev/null || :; }
-clean_with_sudo(){ local paths=("$@") path; local existing_paths=(); for path in "${paths[@]}"; do _expand_wildcards "$path" existing_paths; done; [[ ${#existing_paths[@]} -gt 0 ]] && run_priv rm -rf --preserve-root -- "${existing_paths[@]}" &>/dev/null || :; }
+clean_with_sudo(){ local paths=("$@") path; local existing_paths=(); for path in "${paths[@]}"; do _expand_wildcards "$path" existing_paths; done; [[ ${#existing_paths[@]} -gt 0 ]] && sudo rm -rf --preserve-root -- "${existing_paths[@]}" &>/dev/null || :; }
 _DOWNLOAD_TOOL_CACHED=""
 get_download_tool(){ local skip_aria2=0; [[ ${1:-} == --no-aria2 ]] && skip_aria2=1; if [[ -n $_DOWNLOAD_TOOL_CACHED && $skip_aria2 -eq 0 ]]; then printf '%s' "$_DOWNLOAD_TOOL_CACHED"; return 0; fi; local tool; if [[ $skip_aria2 -eq 0 ]] && has aria2c; then tool=aria2c; elif has curl; then tool=curl; elif has wget2; then tool=wget2; elif has wget; then tool=wget; else return 1; fi; [[ $skip_aria2 -eq 0 ]] && _DOWNLOAD_TOOL_CACHED=$tool; printf '%s' "$tool"; }
 download_file(){ local url=$1 output=$2 tool; tool=$(get_download_tool) || return 1; case $tool in aria2c) aria2c -q --max-tries=3 --retry-wait=1 -d "$(dirname "$output")" -o "$(basename "$output")" "$url" ;; curl) curl -fsSL --retry 3 --retry-delay 1 "$url" -o "$output" ;; wget2) wget2 -q -O "$output" "$url" ;; wget) wget -qO "$output" "$url" ;; *) return 1 ;; esac; }
-cleanup_pacman_lock(){ run_priv rm -f /var/lib/pacman/db.lck &>/dev/null || :; }
+cleanup_pacman_lock(){ sudo rm -f /var/lib/pacman/db.lck &>/dev/null || :; }
 # ============ End of inlined lib/common.sh ============
 
 
@@ -94,7 +91,7 @@ cleanup_pacman_lock(){ run_priv rm -f /var/lib/pacman/db.lck &>/dev/null || :; }
 export HOME="/home/${SUDO_USER:-$USER}"
 
 # Initialize privilege tool
-PRIV_CMD=$(init_priv)
+
 
 # Usage information
 usage() {
@@ -159,14 +156,14 @@ jobs8="$((nproc_count / 2))"
 if [[ -f /sys/devices/system/cpu/intel_pstate/no_turbo ]]; then
   o1="$(</sys/devices/system/cpu/intel_pstate/no_turbo)"
   Reset() {
-    echo "$o1" | run_priv tee "/sys/devices/system/cpu/intel_pstate/no_turbo" &>/dev/null || :
+    echo "$o1" | sudo tee "/sys/devices/system/cpu/intel_pstate/no_turbo" &>/dev/null || :
   }
   # Set performance mode
-  run_priv cpupower frequency-set --governor performance &>/dev/null || :
-  echo 1 | run_priv tee "/sys/devices/system/cpu/intel_pstate/no_turbo" &>/dev/null || :
+  sudo cpupower frequency-set --governor performance &>/dev/null || :
+  echo 1 | sudo tee "/sys/devices/system/cpu/intel_pstate/no_turbo" &>/dev/null || :
 else
   Reset() { :; }
-  run_priv cpupower frequency-set --governor performance &>/dev/null || :
+  sudo cpupower frequency-set --governor performance &>/dev/null || :
 fi
 
 # Benchmark function for parallel/sort tests
@@ -176,7 +173,7 @@ benchmark() {
   local cmd="$*"
   log "${BLU}▶${DEF} $name"
   command hyperfine -w 25 -m 50 -i -S bash \
-    -p "sync; echo 3 | ${PRIV_CMD:-sudo} tee /proc/sys/vm/drop_caches &>/dev/null; resolvectl flush-caches &>/dev/null || :; hash -r" \
+    -p "sync; echo 3 | sudo tee /proc/sys/vm/drop_caches &>/dev/null; resolvectl flush-caches &>/dev/null || :; hash -r" \
     "$cmd"
 }
 
@@ -191,7 +188,7 @@ benchmark_copy() {
   if [[ $EXPORT_JSON -eq 1 ]]; then
     hyperfine \
       --warmup 5 \
-      --prepare "run_priv fstrim -a --quiet-unsupported &>/dev/null; run_priv journalctl --vacuum-time=1s &>/dev/null; sync; echo 3 | run_priv tee /proc/sys/vm/drop_caches &>/dev/null" \
+      --prepare "sudo fstrim -a --quiet-unsupported &>/dev/null; sudo journalctl --vacuum-time=1s &>/dev/null; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches &>/dev/null" \
       --export-json /tmp/hf-"$name".json \
       "$cmd"
 
@@ -203,7 +200,7 @@ benchmark_copy() {
   else
     hyperfine \
       --warmup 5 \
-      --prepare "run_priv fstrim -a --quiet-unsupported &>/dev/null; run_priv journalctl --vacuum-time=1s &>/dev/null; sync; echo 3 | run_priv tee /proc/sys/vm/drop_caches &>/dev/null" \
+      --prepare "sudo fstrim -a --quiet-unsupported &>/dev/null; sudo journalctl --vacuum-time=1s &>/dev/null; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches &>/dev/null" \
       "$cmd"
   fi
 }

--- a/Cachyos/Scripts/gamemd.sh
+++ b/Cachyos/Scripts/gamemd.sh
@@ -14,21 +14,6 @@ xecho(){ printf '%b
 log(){ xecho "$*"; }
 die(){ xecho "${RED}Error:${DEF} $*" >&2; exit 1; }
 confirm(){ local msg="$1"; printf '%s [y/N]: ' "$msg" >&2; read -r ans; [[ $ans == [Yy]* ]]; }
-get_priv_cmd(){ local cmd; for cmd in sudo-rs sudo doas; do if has "$cmd"; then printf '%s' "$cmd"; return 0; fi; done; [[ $EUID -eq 0 ]] || die "No privilege tool found and not running as root"; printf ''; }
-init_priv(){ local priv_cmd; priv_cmd=$(get_priv_cmd); [[ -n $priv_cmd && $EUID -ne 0 ]] && "$priv_cmd" -v; printf '%s' "$priv_cmd"; }
-run_priv(){ local priv_cmd="${PRIV_CMD:-}"; [[ -z $priv_cmd ]] && priv_cmd=$(get_priv_cmd); if [[ $EUID -eq 0 || -z $priv_cmd ]]; then "$@"; else "$priv_cmd" -- "$@"; fi; }
-print_banner(){ local banner="$1" title="${2:-}"; local flag_colors=("$LBLU" "$PNK" "$BWHT" "$PNK" "$LBLU"); local -a lines=(); while IFS= read -r line || [[ -n $line ]]; do lines+=("$line"); done <<<"$banner"; local line_count=${#lines[@]} segments=${#flag_colors[@]}; if ((line_count <= 1)); then printf '%s%s%s
-' "${flag_colors[0]}" "${lines[0]}" "$DEF"; else for i in "${!lines[@]}"; do local segment_index=$((i * (segments - 1) / (line_count - 1))); ((segment_index >= segments)) && segment_index=$((segments - 1)); printf '%s%s%s
-' "${flag_colors[segment_index]}" "${lines[i]}" "$DEF"; done; fi; [[ -n $title ]] && xecho "$title"; }
-get_update_banner(){ cat <<'EOF'
-██╗   ██╗██████╗ ██████╗  █████╗ ████████╗███████╗███████╗
-██║   ██║██╔══██╗██╔══██╗██╔══██╗╚══██╔══╝██╔════╝██╔════╝
-██║   ██║██████╔╝██║  ██║███████║   ██║   █████╗  ███████╗
-██║   ██║██╔═══╝ ██║  ██║██╔══██║   ██║   ██╔══╝  ╚════██║
-╚██████╔╝██║     ██████╔╝██║  ██║   ██║   ███████╗███████║
- ╚═════╝ ╚═╝     ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝╚══════╝
-EOF
-}
 get_clean_banner(){ cat <<'EOF'
  ██████╗██╗     ███████╗ █████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗
 ██╔════╝██║     ██╔════╝██╔══██╗████╗  ██║██║████╗  ██║██╔════╝
@@ -40,7 +25,7 @@ EOF
 }
 print_named_banner(){ local name="$1" title="${2:-Meow (> ^ <)}" banner; case "$name" in update) banner=$(get_update_banner) ;; clean) banner=$(get_clean_banner) ;; *) die "Unknown banner name: $name" ;; esac; print_banner "$banner" "$title"; }
 setup_build_env(){ [[ -r /etc/makepkg.conf ]] && source /etc/makepkg.conf &>/dev/null; export RUSTFLAGS="-Copt-level=3 -Ctarget-cpu=native -Ccodegen-units=1 -Cstrip=symbols"; export CFLAGS="-march=native -mtune=native -O3 -pipe"; export CXXFLAGS="$CFLAGS"; export LDFLAGS="-Wl,-O3 -Wl,--sort-common -Wl,--as-needed -Wl,-z,now -Wl,-z,pack-relative-relocs -Wl,-gc-sections"; export; export CARGO_CACHE_AUTO_CLEAN_FREQUENCY=always; export CARGO_HTTP_MULTIPLEXING=true CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_CACHE_RUSTC_INFO=1 RUSTC_BOOTSTRAP=1; local nproc_count; nproc_count=$(nproc 2>/dev/null || echo 4); export MAKEFLAGS="-j${nproc_count}"; export NINJAFLAGS="-j${nproc_count}"; if has clang && has clang++; then export CC=clang CXX=clang++ AR=llvm-ar NM=llvm-nm RANLIB=llvm-ranlib; if has ld.lld; then export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"; fi; fi; has dbus-launch && eval "$(dbus-launch 2>/dev/null || :)"; }
-run_system_maintenance(){ local cmd=$1; shift; local args=("$@"); has "$cmd" || return 0; case "$cmd" in modprobed-db) "$cmd" store &>/dev/null || :;; hwclock | updatedb | chwd) run_priv "$cmd" "${args[@]}" &>/dev/null || :;; mandb) run_priv "$cmd" -q &>/dev/null || mandb -q &>/dev/null || :;; *) run_priv "$cmd" "${args[@]}" &>/dev/null || :;; esac; }
+run_system_maintenance(){ local cmd=$1; shift; local args=("$@"); has "$cmd" || return 0; case "$cmd" in modprobed-db) "$cmd" store &>/dev/null || :;; hwclock | updatedb | chwd) sudo "$cmd" "${args[@]}" &>/dev/null || :;; mandb) sudo "$cmd" -q &>/dev/null || mandb -q &>/dev/null || :;; *) sudo "$cmd" "${args[@]}" &>/dev/null || :;; esac; }
 capture_disk_usage(){ local var_name=$1; local -n ref="$var_name"; ref=$(df -h --output=used,pcent / 2>/dev/null | awk 'NR==2{print $1, $2}'); }
 find_files(){ if has fd; then fd -H "$@"; else find "$@"; fi; }
 find0(){ local root="$1"; shift; if has fdf; then fdf -H -0 "$@" . "$root"; elif has fd; then fd -H -0 "$@" . "$root"; else find "$root" "$@" -print0; fi; }
@@ -81,21 +66,20 @@ chrome_profiles(){ local root=$1 d; for d in "$root"/Default "$root"/"Profile "*
 ' "$d"; done; }
 _expand_wildcards(){ local path=$1; local -n result_ref=$2; if [[ $path == *\** ]]; then shopt -s nullglob; local -a items=($path); for item in "${items[@]}"; do [[ -e $item ]] && result_ref+=("$item"); done; shopt -u nullglob; else [[ -e $path ]] && result_ref+=("$path"); fi; }
 clean_paths(){ local paths=("$@") path; local existing_paths=(); for path in "${paths[@]}"; do _expand_wildcards "$path" existing_paths; done; [[ ${#existing_paths[@]} -gt 0 ]] && rm -rf --preserve-root -- "${existing_paths[@]}" &>/dev/null || :; }
-clean_with_sudo(){ local paths=("$@") path; local existing_paths=(); for path in "${paths[@]}"; do _expand_wildcards "$path" existing_paths; done; [[ ${#existing_paths[@]} -gt 0 ]] && run_priv rm -rf --preserve-root -- "${existing_paths[@]}" &>/dev/null || :; }
+clean_with_sudo(){ local paths=("$@") path; local existing_paths=(); for path in "${paths[@]}"; do _expand_wildcards "$path" existing_paths; done; [[ ${#existing_paths[@]} -gt 0 ]] && sudo rm -rf --preserve-root -- "${existing_paths[@]}" &>/dev/null || :; }
 _DOWNLOAD_TOOL_CACHED=""
 get_download_tool(){ local skip_aria2=0; [[ ${1:-} == --no-aria2 ]] && skip_aria2=1; if [[ -n $_DOWNLOAD_TOOL_CACHED && $skip_aria2 -eq 0 ]]; then printf '%s' "$_DOWNLOAD_TOOL_CACHED"; return 0; fi; local tool; if [[ $skip_aria2 -eq 0 ]] && has aria2c; then tool=aria2c; elif has curl; then tool=curl; elif has wget2; then tool=wget2; elif has wget; then tool=wget; else return 1; fi; [[ $skip_aria2 -eq 0 ]] && _DOWNLOAD_TOOL_CACHED=$tool; printf '%s' "$tool"; }
 download_file(){ local url=$1 output=$2 tool; tool=$(get_download_tool) || return 1; case $tool in aria2c) aria2c -q --max-tries=3 --retry-wait=1 -d "$(dirname "$output")" -o "$(basename "$output")" "$url" ;; curl) curl -fsSL --retry 3 --retry-delay 1 "$url" -o "$output" ;; wget2) wget2 -q -O "$output" "$url" ;; wget) wget -qO "$output" "$url" ;; *) return 1 ;; esac; }
-cleanup_pacman_lock(){ run_priv rm -f /var/lib/pacman/db.lck &>/dev/null || :; }
+cleanup_pacman_lock(){ sudo rm -f /var/lib/pacman/db.lck &>/dev/null || :; }
 # ============ End of inlined lib/common.sh ============
 
 
 
 # Initialize privilege tool
-PRIV_CMD=$(init_priv)
 
 # Needs testing
-echo 0 | run_priv tee /sys/kernel/mm/transparent_hugepage/use_zero_page &>/dev/null
-echo 0 | run_priv tee /sys/kernel/mm/transparent_hugepage/shrink_underused &>/dev/null
+echo 0 | sudo tee /sys/kernel/mm/transparent_hugepage/use_zero_page &>/dev/null
+echo 0 | sudo tee /sys/kernel/mm/transparent_hugepage/shrink_underused &>/dev/null
 
 # Known
 echo always | sudo tee /sys/kernel/mm/transparent_hugepage/enabled &>/dev/null


### PR DESCRIPTION
Removed get_priv_cmd, init_priv, and run_priv functions from all scripts and replaced them with direct sudo usage for simplicity and consistency.

Changes:
- Cachyos scripts: Clean.sh, Updates.sh, archmaint.sh, Rank.sh
- Cachyos/Scripts: bench.sh, fstab-tune.sh, gamemd.sh
- RaspberryPi/Scripts: pi-minify.sh, Setup.sh
- Updated bash.instructions.md to reflect new sudo-only approach

This simplifies the codebase by removing the privilege tool detection logic and standardizing on sudo throughout all scripts.