### PR TITLE
Update CLAUDE.MD with comprehensive repository analysis

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -2,11 +2,11 @@
 
 ## Repository Overview
 
-**Linux-OS** is a comprehensive collection of scripts and resources for managing, optimizing, and customizing Linux distributions, with primary focus on Arch-based systems (CachyOS, EndeavourOS) and Raspberry Pi self-hosting. The repository contains 45 actively maintained shell scripts emphasizing performance optimization, privacy hardening, and modern tooling.
+**Linux-OS** is a comprehensive collection of scripts and resources for managing, optimizing, and customizing Linux distributions, with primary focus on Arch-based systems (CachyOS, EndeavourOS) and Raspberry Pi self-hosting. The repository contains 73 actively maintained shell scripts emphasizing performance optimization, privacy hardening, and modern tooling.
 
-**Statistics**: 45 shell scripts | 79 config/documentation files | ~273 lines eliminated via lib/common.sh
+**Statistics**: 73 shell scripts | 81+ config/documentation files | Self-contained architecture
 
-**Recent Focus**: Cleanup and script consolidation (commits: 947711b, f63d908), Parallel execution optimization (commit: e4c56c6)
+**Recent Focus**: RaspberryPi reorganization (commit: 132d4ae), Bash standardization (commit: 879d901), Script consolidation (commit: 5243dc2)
 
 ## Core Directives
 Autonomous execution. Minimal confirmations. Token-efficient responses. Primary focus: Bash scripts & system configs.
@@ -30,51 +30,95 @@ y=Yes n=No c=Continue r=Review u=Undo | cfg=config impl=implementation arch=arch
 ```
 /home/user/Linux-OS/
 ├── .github/                    # GitHub automation & AI configuration
-│   ├── agents/                 # AI agent definitions (bash-architect, performance-engineer, etc.)
-│   ├── chatmodes/              # Conversational AI modes
+│   ├── agents/                 # AI agent definitions
+│   ├── chatmodes/              # Conversational AI modes (6 modes)
 │   ├── copilot/                # GitHub Copilot instructions
-│   ├── instructions/           # Language-specific guidelines (bash, rust, python, etc.)
-│   ├── prompts/                # Prompt templates
-│   └── workflows/              # CI/CD (shell.yml, mega-linter.yml, etc.)
-├── Cachyos/                    # CachyOS/Arch-based distribution scripts
-│   ├── lib/common.sh           # Shared functions library (15,945 bytes, DRY principle)
-│   ├── Updates.sh              # System update automation
-│   ├── Clean.sh                # System cleanup & maintenance
-│   ├── Rank.sh                 # Mirror ranking & optimization
-│   ├── archmaint.sh            # Comprehensive Arch maintenance (705 lines)
+│   ├── instructions/           # Language-specific guidelines (8 files)
+│   ├── prompts/                # Prompt templates (8 templates)
+│   ├── workflows/              # CI/CD (6 workflows)
+│   └── ISSUE_TEMPLATE/         # GitHub issue templates
+├── Cachyos/                    # CachyOS/Arch-based distribution scripts (54 scripts)
+│   ├── Updates.sh              # System update automation (144 lines)
+│   ├── Clean.sh                # System cleanup & maintenance (269 lines)
+│   ├── Rank.sh                 # Mirror ranking & optimization (411 lines)
+│   ├── Setup.sh                # Initial system setup (69 lines)
+│   ├── archmaint.sh            # Comprehensive Arch maintenance (1,153 lines)
 │   ├── Firefox/                # Firefox configuration & telemetry scripts
-│   ├── Rust/                   # Rust build optimization
-│   └── Scripts/                # Main automation scripts
-│       ├── Install.sh          # Automated package installation
-│       ├── AutoSetup.sh        # System configuration automation
-│       ├── Privacy-Config.sh   # Privacy hardening
-│       ├── Fix.sh              # System fixes and troubleshooting
-│       ├── bench.sh / bench-cp.sh  # Benchmarking utilities
-│       ├── bleachbit.sh        # BleachBit cleaners installation
-│       ├── fstab-tune.sh       # Filesystem tuning
-│       ├── gamemd.sh           # Gaming-related optimizations
-│       ├── Android/            # Android device optimization
-│       ├── MC/                 # Minecraft server management
-│       ├── WIP/                # Work-in-progress scripts
-│       │   └── Toolkit/        # Development toolkit utilities
-│       ├── other/              # Miscellaneous utilities
-│       └── shell-tools/        # Shell utility scripts
-│           └── dietpi/         # DietPi-specific tools
-├── RaspberryPi/                # Raspberry Pi specific scripts
-│   ├── lib/                    # Pi-specific libraries (common.sh, cleaning.sh, text.sh)
-│   ├── update.sh               # Pi system updates
-│   ├── PiClean.sh              # Pi cleanup utilities
-│   ├── raspi-f2fs.sh           # F2FS filesystem conversion (1,032 lines)
-│   ├── privacy-script.sh       # Pi privacy hardening
-│   ├── forward.sh              # Port forwarding utilities
-│   ├── Scripts/                # Pi automation scripts
-│   │   └── Nextcloud/          # Nextcloud server setup
+│   ├── Rust/                   # Rust build optimization (4 scripts)
+│   │   ├── Strip-rust.sh
+│   │   ├── rustify.sh
+│   │   ├── cargo-build.sh
+│   │   └── rustbuild.sh
+│   ├── packages-repo.txt       # Repository packages list (178 packages)
+│   ├── packages-aur.txt        # AUR packages list (11 packages)
+│   └── Scripts/                # Main automation scripts (37 scripts)
+│       ├── Install.sh          # Automated package installation (17,593 lines)
+│       ├── AutoSetup.sh        # System configuration automation (7,892 lines)
+│       ├── Fix.sh              # System fixes and troubleshooting (12,790 lines)
+│       ├── bench.sh            # System benchmarking (18,760 lines)
+│       ├── bleachbit.sh        # BleachBit cleaners installation (741 lines)
+│       ├── fstab-tune.sh       # Filesystem tuning (11,922 lines)
+│       ├── gamemd.sh           # Gaming optimizations (11,664 lines)
+│       ├── gpg.sh              # GPG key management (280 lines)
+│       ├── Android/            # Android device optimization (11 scripts)
+│       │   ├── android-optimize.sh
+│       │   ├── adb-experimental-tweaks.sh
+│       │   ├── Shizuku-rish.sh
+│       │   ├── mkshrc.sh
+│       │   ├── optimize_apk.sh
+│       │   └── Toolkit/        # Android toolkit utilities (6 scripts)
+│       ├── WIP/                # Work-in-progress scripts (12 scripts)
+│       │   ├── Privacy-Config.sh
+│       │   ├── bash-lazyrc.sh
+│       │   ├── gittool.sh
+│       │   ├── min-cli.sh
+│       │   ├── nvidia.sh
+│       │   ├── printer.sh
+│       │   └── (others)
+│       └── shell-tools/        # Shell utility scripts (15 scripts)
+│           ├── minify.sh
+│           ├── vscodium-patch.sh
+│           ├── imageoptim.sh
+│           ├── inifmt.sh
+│           ├── vnfetch.sh
+│           ├── flagscii.sh
+│           ├── optimal-mtu.sh
+│           ├── pachelp.sh
+│           ├── template.sh
+│           └── dietpi/         # DietPi-specific tools (2 scripts)
+├── RaspberryPi/                # Raspberry Pi specific scripts (17 scripts)
+│   ├── update.sh               # Pi system updates (100 lines)
+│   ├── PiClean.sh              # Pi cleanup utilities (136 lines)
+│   ├── raspi-f2fs.sh           # F2FS filesystem conversion (1,045 lines)
+│   ├── forward.sh              # Port forwarding utilities (24 lines)
+│   ├── Scripts/                # Pi automation scripts (13 scripts)
+│   │   ├── Setup.sh            # Comprehensive Pi setup (14,768 lines)
+│   │   ├── apkg.sh             # APT package manager wrapper (15,880 lines)
+│   │   ├── pi-minify.sh        # System minimization + privacy (15,399 lines)
+│   │   ├── blocklist.sh        # Adblock list management (6,581 lines)
+│   │   ├── docker.sh           # Docker configuration (1,545 lines)
+│   │   ├── Docker-clean.sh     # Docker cleanup (4,261 lines)
+│   │   ├── Fix.sh              # Pi system fixes (3,908 lines)
+│   │   ├── Housekeep.sh        # System housekeeping (818 lines)
+│   │   ├── Kbuild.sh           # Kernel build automation (4,200 lines)
+│   │   ├── copyparty.sh        # CopyParty setup (1,333 lines)
+│   │   ├── podman.sh           # Podman container management (2,663 lines)
+│   │   ├── sqlite-tune.sh      # SQLite optimization (4,024 lines)
+│   │   └── Nextcloud/          # Nextcloud server setup (1 script)
+│   ├── docs/                   # Pi documentation
+│   │   ├── TODO.md
+│   │   └── raspi-kernel-patches.md
 │   └── dots/                   # Configuration files (apt.conf, apt-fast.conf)
-├── Scripts/                    # General cross-platform scripts
-├── Linux-Settings/             # System configuration references (Compiler.txt, Kernel.txt)
+├── Scripts/                    # General cross-platform scripts (2 scripts)
+│   ├── Debloat.sh              # Cross-distro debloating (81 lines)
+│   └── media-opt.sh            # Media file optimization (418 lines)
+├── Linux-Settings/             # System configuration references
 ├── CLAUDE.MD                   # AI assistant instructions (this file)
-├── Shell-book.md               # Bash scripting reference (14,406 bytes)
-├── USEFUL.MD                   # Curated resources & compiler flags
+├── GEMINI.MD                   # Gemini AI instructions (6,119 bytes)
+├── USEFUL.MD                   # Curated resources (1,971 bytes)
+├── Shell-book.md               # Bash scripting reference (14,428 bytes)
+├── Searchxng.md                # SearXNG privacy search engine reference
+├── todo.md                     # Project task tracking
 └── README.md                   # Quick-start guide with curl-able commands
 ```
 
@@ -84,41 +128,62 @@ y=Yes n=No c=Continue r=Review u=Undo | cfg=config impl=implementation arch=arch
 - **Cachyos/Updates.sh** - System update automation with package manager detection
 - **Cachyos/Clean.sh** - System cleanup with smart cache management
 - **Cachyos/Rank.sh** - Mirror ranking with parallel testing
-- **Cachyos/archmaint.sh** (705 lines) - Comprehensive maintenance suite
-- **Cachyos/Scripts/Install.sh** - Automated package installation
-- **Cachyos/Scripts/AutoSetup.sh** - System configuration automation
-- **Cachyos/Scripts/Privacy-Config.sh** - Privacy hardening configuration
+- **Cachyos/archmaint.sh** (1,153 lines) - Comprehensive maintenance suite
+- **Cachyos/Scripts/Install.sh** (17,593 lines) - Automated package installation (largest)
+- **Cachyos/Scripts/AutoSetup.sh** (7,892 lines) - System configuration automation
 - **Cachyos/Scripts/bleachbit.sh** - BleachBit extra cleaners installation
-- **RaspberryPi/raspi-f2fs.sh** (1,032 lines) - F2FS conversion utility
-- **RaspberryPi/privacy-script.sh** - Raspberry Pi privacy hardening
+- **RaspberryPi/raspi-f2fs.sh** (1,045 lines) - F2FS conversion utility
+- **RaspberryPi/Scripts/pi-minify.sh** (15,399 lines) - Debian minimization + privacy hardening
 
-### Library System (DRY Principle)
-**Cachyos/lib/common.sh** (15,945 bytes) - Eliminates ~273 lines of duplication across 8 scripts
-- Color definitions & utility functions
-- Package manager detection (paru → yay → pacman)
-- Error handling patterns
-- Common operation functions
+### Script Architecture (Self-Contained)
+**IMPORTANT**: The repository previously used a centralized library system (`lib/common.sh`) but this was **removed** in commit 59a8613. All scripts are now **self-contained** with inlined utility functions.
 
-**RaspberryPi/lib/** - Pi-specific libraries
-- `common.sh` (4,952 bytes) - Core utilities
-- `cleaning.sh` (4,701 bytes) - Cleaning functions
-- `text.sh` (3,701 bytes) - Banner/text utilities
+**Standard Script Structure** (from Shell-book.md):
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob globstar
+IFS=$'\n\t'
+export LC_ALL=C LANG=C LANGUAGE=C
+
+# Color definitions (inlined in each script)
+BLK=$'\e[30m' WHT=$'\e[37m' BWHT=$'\e[97m'
+RED=$'\e[31m' GRN=$'\e[32m' YLW=$'\e[33m'
+BLU=$'\e[34m' CYN=$'\e[36m' LBLU=$'\e[38;5;117m'
+MGN=$'\e[35m' PNK=$'\e[38;5;218m'
+DEF=$'\e[0m' BLD=$'\e[1m'
+
+# Utility functions (inlined in each script)
+has() { command -v "$1" &>/dev/null; }
+log() { printf '%b\n' "$*"; }
+die() { printf '%b\n' "${RED}Error:${DEF} $*" >&2; exit 1; }
+```
+
+**Pattern**: Each script includes its own complete set of:
+- Color/formatting variable definitions
+- Helper functions (`has`, `log`, `warn`, `die`, `confirm`)
+- Package manager detection logic
+- Environment variable exports
 
 ### Configuration Files
-- **.editorconfig** - Universal formatting (shfmt, 2-space indent, bash variant detection, auto shell variant)
-- **.shellcheckrc** - Linting rules (enable=all, specific exclusions, source-path=SCRIPTDIR)
+- **.editorconfig** (264 lines) - Universal formatting (shfmt, 2-space indent, bash variant detection)
+- **.shellcheckrc** - Linting rules (enable=all, 16 specific exclusions, source-path=SCRIPTDIR)
 - **.gitattributes** (2,381 bytes) - Git file handling
 - **.gitignore** (2,160 bytes) - Security files, build artifacts, editor configs
 
 ### Package Manifests
-- **Cachyos/packages-repo.txt** - Repository packages list (178 packages)
-- **Cachyos/packages-aur.txt** - AUR packages list
-- Primary tools: cargo toolchain (cargo-c, cargo-cache, cargo-llvm-cov, cargo-pgo, sccache), modern CLI utilities (bat, dust, eza, fd), performance tools (hyperfine, btop, glances)
+- **Cachyos/packages-repo.txt** - Repository packages (178 packages)
+  - CachyOS-specific: cachyos-settings, cachyos-hooks, cachyos-mirrorlist, cachyos-rate-mirrors
+  - Toolchain: cargo-c, cargo-cache, sccache, llvm-bolt, rust-src
+  - Modern CLI: bat, dust, eza, fd, btop, glances, hyperfine
+  - Gaming: prismlauncher, proton-ge-custom, protonplus
+- **Cachyos/packages-aur.txt** - AUR packages (11 packages)
+  - aria2-unlimited, rust-parallel, uutils variants, ssh3
 
 ### Documentation Structure
 - **README.md** - Quick-start with curl commands
 - **CLAUDE.MD** - AI assistant development guide (this file)
-- **Shell-book.md** (14,406 bytes) - Bash reference, templates, snippets
+- **Shell-book.md** (14,428 bytes) - Bash reference, templates, snippets
 - **USEFUL.MD** (1,971 bytes) - Compiler flags, external resources
 - **GEMINI.MD** (6,119 bytes) - Additional AI instructions
 - **todo.md** - Project task tracking
@@ -148,14 +213,24 @@ set -euo pipefail  # Use for critical scripts
 set -eo pipefail   # Use when unset variables are acceptable
 ```
 
-### Sourcing Library
+### Standard Boilerplate (Self-Contained Scripts)
+Since the library consolidation was removed, each script includes its own:
 ```bash
-# Source common library
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/common.sh
-source "$SCRIPT_DIR/lib/common.sh" || {
-  echo "Failed to load common library" >&2
-  exit 1
+# Common pattern across scripts:
+set -euo pipefail
+shopt -s nullglob globstar
+IFS=$'\n\t'
+export LC_ALL=C LANG=C LANGUAGE=C
+
+# Inlined helper functions
+has() { command -v "$1" &>/dev/null; }
+log() { printf '%b\n' "$*"; }
+die() { log "${RED}Error:${DEF} $*" >&2; exit 1; }
+confirm() {
+  local msg="$1"
+  printf '%s [y/N]: ' "$msg" >&2
+  read -r ans
+  [[ $ans == [Yy]* ]]
 }
 ```
 
@@ -163,7 +238,7 @@ source "$SCRIPT_DIR/lib/common.sh" || {
 
 ### Package Management
 - **Detection Chain**: `paru` → `yay` → `pacman` (Arch-based) | `apt`/`nala` (Debian-based)
-- **Privilege Escalation Chain**: `sudo-rs` → `sudo` → `doas` (detected via lib/common.sh)
+- **Privilege Escalation**: `sudo-rs` → `sudo` → `doas` (detected at runtime)
 - **Pre-Installation Checks**: `pacman -Q pkg` | `flatpak list` | `cargo install --list`
 - **Distro-Specific Hints**: Include installation commands for both ecosystems
   - Example: `(Arch: pacman -S tool)` `(Debian: apt-get install -y tool)`
@@ -250,10 +325,12 @@ Process: Write failing test (Red) → Implement minimal passing code (Green) →
 All must be true: Tests pass | Zero warnings | Single logical unit | Clear message
 Preference: Small, frequent, independent commits
 
-**Recent Commit Pattern** (as of Nov 2025):
-- Script cleanup and consolidation (removed outdated scripts: Install-old.sh, Repoadd.sh, Env.sh, shopt.sh, minify-opt.sh)
-- Performance optimizations (parallel execution)
-- Container tooling updates (Podman)
+**Recent Commit Pattern** (November 2025):
+- Script cleanup and consolidation (deleted: adbclean2.sh, uu-sym.sh, shizuku_merge.sh, buildkernel.sh, hypershell.sh)
+- RaspberryPi folder restructuring (commit: 132d4ae)
+- Privacy script consolidation (merged privacy-script.sh into pi-minify.sh)
+- Bash standardization (commit: 879d901)
+- Documentation cleanup (deleted: Compiler.txt, Kernel.txt, Sched-ext.txt)
 - Single-purpose, atomic changes
 
 ### Code Quality Standards
@@ -261,15 +338,15 @@ Preference: Small, frequent, independent commits
 - Loose coupling via interfaces
 - Early returns for clarity
 - Avoid premature abstraction
-- Eliminate duplication immediately (use lib/common.sh)
+- Eliminate duplication (inline common patterns, reference Shell-book.md)
 - Explicit dependencies, clear intent
 - Small, focused functions (<50 lines preferred)
 
 ### Prohibited Patterns
 ❌ Hardcoded values (use constants/config/environment)
-❌ Repetitive code blocks (create functions or use lib/common.sh)
+❌ Repetitive code blocks (create functions or reference templates)
 ❌ Duplicated error handling (unify patterns)
-❌ Replicated logic (abstract to library)
+❌ Replicated logic (inline or abstract to reusable pattern)
 ❌ Parsing `ls` output (use globs, arrays, or find)
 ❌ Unnecessary subshells (use mapfile, process substitution)
 
@@ -297,7 +374,7 @@ Preference: Small, frequent, independent commits
 1. Run code quality pipeline (shfmt → shellcheck → shellharden)
 2. Test script functionality (dry-run if available)
 3. Update README.md if entrypoint changed
-4. Update lib/common.sh if creating reusable functions
+4. Update Shell-book.md if creating new reusable patterns
 5. Verify no sensitive data committed (.env, tokens, keys)
 6. Single logical change per commit
 
@@ -309,7 +386,7 @@ curl -fsSL https://raw.githubusercontent.com/Ven0m0/Linux-OS/main/path/to/script
 
 ## Build Optimization & Toolchain
 
-### Compiler Flags (see Linux-Settings/Compiler.txt)
+### Compiler Flags
 - **Toolchain**: LLVM/Clang preferred, GCC fallback
 - **Linker**: `mold` → `lld` → `gold` → `ld`
 - **Caching**: `sccache` (Rust), `ccache` (C/C++)
@@ -322,7 +399,7 @@ curl -fsSL https://raw.githubusercontent.com/Ven0m0/Linux-OS/main/path/to/script
 - Target CPU optimization flags
 
 ## Agent System
-Available specialized agents (see `.github/agents.yml`):
+Available specialized agents (see `.github/agents/`):
 - **bash-architect**: Script design & architecture
 - **performance-engineer**: Profiling & optimization
 - **config-specialist**: Configuration management
@@ -333,30 +410,26 @@ Available specialized agents (see `.github/agents.yml`):
 Invoke: `@agent-name [task]`
 
 ## Chat Modes
-Available modes (see `.github/chat-modes.yml`):
-- `quick-fix`: Fast bug fixes
-- `refactor`: Code quality improvement
-- `feature`: New feature development
-- `debug`: Problem investigation
-- `optimize`: Performance tuning
-- `review`: Code quality assessment
-- `explain`: Concept explanation
-- `script`: Script generation
+Available modes (see `.github/chatmodes/`):
+- `Thinking-Beast-Mode`: Deep reasoning mode
+- `critical-thinking`: Analytical problem solving
+- `janitor`: Code cleanup and maintenance
+- `prompt-engineer`: Prompt optimization
+- `rust-gpt-4.1-beast-mode`: Rust development
+- `software-engineer-agent-v1`: General engineering
 
 Activate: `/mode [mode-name]`
 
 ## Prompt Templates
-Common templates (see `.github/prompt-templates.yml`):
-- `optimize-script`: Performance optimization
-- `add-error-handling`: Error handling patterns
-- `make-distro-agnostic`: Multi-distro support
-- `add-interactive-mode`: fzf integration
-- `security-audit`: Security review
-- `write-tests`: Test generation
-- `generate-readme`: Documentation
-- `modernize-tools`: Tool upgrades (replace GNU with Rust tools)
-- `add-dry-run`: Safe preview mode
-- `parallel-processing`: Concurrent execution
+Common templates (see `.github/prompts/`):
+- `bash-script`: Generate bash scripts
+- `boost`: Performance enhancement
+- `copilot-instructions-blueprint-generator`: Create copilot configs
+- `create-agentsmd`: Agent configuration generation
+- `create-llms`: LLM instruction generation
+- `create-readme`: Documentation generation
+- `editorconfig`: EditorConfig generation
+- `review-and-refactor`: Code quality review
 
 Use: `/template [template-name]`
 
@@ -377,7 +450,7 @@ Use: `/template [template-name]`
 
 ### Privacy & Hardening
 - Firefox telemetry removal (Cachyos/Firefox/)
-- Privacy configuration scripts (Privacy-Config.sh)
+- Privacy configuration scripts (pi-minify.sh includes privacy hardening)
 - Debloating utilities (Debloat.sh)
 - Pi-hole ad blocking (RaspberryPi/Scripts/)
 
@@ -391,20 +464,31 @@ Use: `/template [template-name]`
 
 ## Recent Repository Changes
 
-### Nov 2025 Cleanup Sprint
-- Removed deprecated scripts (Install-old.sh, Repoadd.sh, Env.sh, shopt.sh, minify-opt.sh)
-- Consolidated overlapping functionality
-- Reduced script count from 100+ to 45 actively maintained scripts
-- Updated CLAUDE.MD with current repository state
+### November 2025 Refactoring
+**Major Changes**:
+- **Script consolidation**: Merged privacy-script.sh into pi-minify.sh (commit: 5243dc2)
+- **RaspberryPi reorganization**: Refactored folder structure (commit: 132d4ae)
+- **Bash standardization**: Applied bashisms across all scripts (commit: 879d901)
+- **Documentation cleanup**: Deleted Compiler.txt, Kernel.txt, Sched-ext.txt
+- **WIP cleanup**: Removed deprecated scripts (adbclean2, uu-sym, shizuku_merge, buildkernel, hypershell)
+- **Script relocation**: Moved rustbuild.sh from WIP to Rust/ directory
 
-### Performance Improvements (commit: e4c56c6)
-- Parallel execution optimization in core scripts
-- Enhanced batch operations
-- Improved subprocess management
+### Architectural Changes
+- **Library consolidation removed** (commit: 59a8613): Deleted lib/common.sh
+- **Self-contained scripts**: All utility functions now inlined
+- **Privilege escalation refactoring** (commit: 94205f3): Replaced functions with direct sudo
+- **Comprehensive linting** (commit: c7fa5d2): Applied formatting across all file types
+
+### Script Count Evolution
+- **Previous**: ~45 actively maintained scripts (as of Nov 18)
+- **Current**: 73 shell scripts (as of Nov 22)
+  - Cachyos/: 54 scripts (74%)
+  - RaspberryPi/: 17 scripts (23%)
+  - Scripts/: 2 scripts (3%)
 
 ---
 
-**Last Updated**: 2025-11-18 (commit: 947711b - cleanup and script consolidation)
+**Last Updated**: 2025-11-22 (commit: 83af6fe - Delete Linux-Settings/Compiler.txt)
 **Maintainer**: Ven0m0
 **Contributors**: copilot-swe-agent[bot], Claude
 


### PR DESCRIPTION
- Update script count from 45 to 73 (actual current count)
- Remove references to deleted lib/common.sh (removed in commit 59a8613)
- Document self-contained script architecture with inlined utilities
- Add detailed directory structure with script counts per folder
- Update recent changes section with November 2025 refactoring
- Document RaspberryPi reorganization (commit 132d4ae)
- Note privacy-script.sh merge into pi-minify.sh (commit 5243dc2)
- Update last modified date to 2025-11-22
- Add comprehensive breakdown of all 73 scripts by location
- Clarify that scripts now inline their own helper functions
- Document architectural change from library to self-contained pattern