### PR TITLE
Fix git clone command syntax in todo.md

### DIFF
--- a/Cachyos/todo.md
+++ b/Cachyos/todo.md
@@ -25,7 +25,7 @@ https://github.com/deadc0de6/dotdrop
 ```
 
 ```bash
-git clone --depth 1--shallow-submodules --filter='blob:none'
+git clone --depth 1 --shallow-submodules --filter='blob:none'
 ```
 
 ## PGO


### PR DESCRIPTION
Add missing space between --depth 1 and --shallow-submodules flags. The command was malformed and would fail if executed.

Fixed: git clone --depth 1--shallow-submodules
To:    git clone --depth 1 --shallow-submodules