### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/Cachyos/git-fetch.py
+++ b/Cachyos/git-fetch.py
@@ -25,8 +25,9 @@ def parse_url(url: str) -> RepoSpec:
     """Extract repo metadata from GitHub/GitLab URL."""
     u = urllib.parse.urlparse(url)
     parts = [p for p in u.path.strip("/").split("/") if p]
+    host = u.hostname or ""
 
-    if "github.com" in u.netloc:
+    if host == "github.com":
         if len(parts) < 2:
             raise ValueError(f"Invalid GitHub URL: {url}")
         owner, repo = parts[0], parts[1]
@@ -37,7 +38,7 @@ def parse_url(url: str) -> RepoSpec:
             path = "/".join(parts[4:]) if len(parts) > 4 else ""
         return RepoSpec("github", owner, repo, path, branch)
 
-    if "gitlab.com" in u.netloc:
+    if host == "gitlab.com":
         if len(parts) < 2:
             raise ValueError(f"Invalid GitLab URL: {url}")
         owner, repo = parts[0], parts[1]


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/Linux-OS/security/code-scanning/12](https://github.com/Ven0m0/Linux-OS/security/code-scanning/12)

In general, the fix is to avoid substring checks on the full `netloc` and instead parse out the hostname and compare it against exact allowed values (or well‑defined suffixes, if subdomains are intended). Python’s `urllib.parse.urlparse` already provides the `hostname` attribute, which strips port numbers and userinfo, so we should use that instead of `netloc`.

Concretely, in `parse_url` we should assign `host = u.hostname` and then replace `if "github.com" in u.netloc:` with an equality or suffix check on `host`. For public GitHub/GitLab, the best behavior is to accept only the canonical origins: `github.com` and `gitlab.com`. That means:
- `if host == "github.com":` for GitHub
- `if host == "gitlab.com":` for GitLab  

This preserves existing functionality for standard URLs, while removing acceptance of hosts that merely contain those strings. We don’t need any new imports since `urllib.parse` is already used. The changes are localized to `parse_url` in `Cachyos/git-fetch.py` around lines 24–51.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
