### PR TITLE
Refactor: Use `run_apt` in `RaspberryPi/update.sh`

### DIFF
--- a/RaspberryPi/update.sh
+++ b/RaspberryPi/update.sh
@@ -103,8 +103,7 @@ update_packages() {
     sudo nala autopurge
   else
     # Combine apt operations
-    yes | sudo apt-get update -y --fix-missing \
-      && sudo apt-get dist-upgrade -y --no-install-recommends --fix-broken || :
+    run_apt update && run_apt dist-upgrade || :
     clean_apt_cache
   fi
 


### PR DESCRIPTION
Refactored `update_packages` in `RaspberryPi/update.sh` to use the helper function `run_apt` for the fallback `apt-get` operations. This removes code duplication and ensures consistent application of flags like `--no-install-recommends` and `-o Acquire::Languages=none`.

The change replaces:
  `yes | sudo apt-get update ... && sudo apt-get dist-upgrade ...`
with:
  `run_apt update && run_apt dist-upgrade`

This resolves the code health issue of `run_apt` being unused.

---
*PR created automatically by Jules for task [16518707553363917329](https://jules.google.com/task/16518707553363917329) started by @Ven0m0*