### PR TITLE
🧹 Fix unreachable process_image function in media-optimizer.sh

### DIFF
--- a/Cachyos/Scripts/Android/media-optimizer.sh
+++ b/Cachyos/Scripts/Android/media-optimizer.sh
@@ -671,4 +671,6 @@ main() {
 }
 
 # Run the main function with all arguments
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Wrapped the call to `main "$@"` at the end of the script in an `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then ... fi` block.

💡 **Why:** How this improves maintainability
When `xargs` parallelizes operations, it sources the script itself using `bash -c 'source "$0"; process_image "{}"' "$0"`. Without the conditional check, this unconditional call to `main` caused the script to re-execute instead of exposing its internal functions (like `process_image`) to the `xargs` subshell, making `process_image` unreachable. The fix allows the script to be cleanly sourced by tools without causing infinite loops or unintended execution.

✅ **Verification:** How you confirmed the change is safe
Validated syntax with `bash -n` and verified no regressions with `./lint-format.sh`. Tested the conditional check using standard bash patterns.

✨ **Result:** The improvement achieved
Functions inside the script can now be reliably accessed via `source` within subshells, ensuring `process_image` and other internal tools are reachable when invoked for parallel processing via `xargs`.

---
*PR created automatically by Jules for task [6316634094750059097](https://jules.google.com/task/6316634094750059097) started by @Ven0m0*