### PR TITLE
🧹 [code health] fix gh-auto-merge argument parsing missing values

### DIFF
--- a/Cachyos/Scripts/WIP/gh/gh-auto-merge.sh
+++ b/Cachyos/Scripts/WIP/gh/gh-auto-merge.sh
@@ -34,11 +34,11 @@ main(){
   while [[ $# -gt 0 ]]; do
     case $1 in
       -h|--help) usage; exit 0;;
-      -q|--query) QUERY=$2; shift 2;;
-      -n|--limit) LIMIT=$2; shift 2;;
-      -b|--branch) BRANCH=$2; shift 2;;
-      -t|--title) TITLE=$2; shift 2;;
-      --prs) prs=$2; shift 2;;
+      -q|--query) [[ -n ${2:-} ]] || die "Missing argument for $1"; QUERY=$2; shift 2;;
+      -n|--limit) [[ -n ${2:-} ]] || die "Missing argument for $1"; LIMIT=$2; shift 2;;
+      -b|--branch) [[ -n ${2:-} ]] || die "Missing argument for $1"; BRANCH=$2; shift 2;;
+      -t|--title) [[ -n ${2:-} ]] || die "Missing argument for $1"; TITLE=$2; shift 2;;
+      --prs) [[ -n ${2:-} ]] || die "Missing argument for $1"; prs=$2; shift 2;;
       --skip-checks) skip_checks=true; shift;;
       --dry-run) dry_run=true; shift;;
       *) die "Unknown: $1";;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `gh-auto-merge.sh` script parsed arguments in a way that assumed flags requiring values always had a subsequent argument. If a flag like `-q` or `--branch` was passed as the last argument without a value, the script would blindly execute `shift 2`, potentially leading to a `shift count out of range` error and unexpected behavior.

💡 **Why:** How this improves maintainability
This update ensures that the script robustly handles missing arguments by explicitly checking that the next argument (`$2`) is not empty (`[[ -n ${2:-} ]]`) before shifting. If the argument is missing, the script gracefully exits with a clear error message. This pattern prevents hidden errors and crashes, improving the reliability and readability of the argument parsing logic.

✅ **Verification:** How you confirmed the change is safe
- Verified syntax with `bash -n`.
- Ran the script passing `-q` without a parameter, confirming that it now exits properly with `Missing argument for -q` instead of attempting to shift out of bounds.

✨ **Result:** The improvement achieved
The argument parsing in `gh-auto-merge.sh` is now much safer and correctly guards against missing argument inputs.

---
*PR created automatically by Jules for task [17280614051039773336](https://jules.google.com/task/17280614051039773336) started by @Ven0m0*