### PR TITLE
🧹 [Code Health] Replace slow loop with grep in lookup_gametdb

### DIFF
--- a/Cachyos/Scripts/WIP/emu/wbfsmv.sh
+++ b/Cachyos/Scripts/WIP/emu/wbfsmv.sh
@@ -65,12 +65,11 @@ load_cache(){
   [[ -f ${CACHE_DB} ]]
 }
 lookup_gametdb(){
-  local id=$1 key val
+  local id=$1 val
   load_cache || return 1
-  while IFS='=' read -r key val; do
-    [[ ${key^^} == "${id^^}" ]] && { printf '%s\n' "$val"; return 0; }
-  done <"$CACHE_DB"
-  return 1
+  val=$(grep -im1 "^${id}=" "$CACHE_DB") || return 1
+  printf '%s\n' "${val#*=}"
+  return 0
 }
 get_id(){
   local f=$1 id="" skip=0


### PR DESCRIPTION
🎯 **What:** Replaced the inefficient `while read` shell loop in `lookup_gametdb` inside `Cachyos/Scripts/WIP/emu/wbfsmv.sh` with a much faster `grep` lookup.
💡 **Why:** By extracting strings directly via `grep` and a Bash parameter expansion instead of linearly scanning an entire cache database line-by-line using a Bash loop, the performance is significantly improved.
✅ **Verification:** Verified by generating a mock Gametdb file and testing both hits and misses, ensuring the bash pipeline correctly propagates the exit code on a mismatch without needing to alter global bash options (`pipefail`). Confirmed via `bash -n` and local testing.
✨ **Result:** Substantially faster string lookups and cleaner code structure.

---
*PR created automatically by Jules for task [1197198945445771446](https://jules.google.com/task/1197198945445771446) started by @Ven0m0*