### PR TITLE
🔒 Fix TOCTOU symlink attack in log truncation

### DIFF
--- a/RaspberryPi/Scripts/pi-minify.sh
+++ b/RaspberryPi/Scripts/pi-minify.sh
@@ -163,10 +163,18 @@ clean_caches() {
   run rm -f ~/.{bash,python}_history 2>/dev/null || :
   sudo rm -f /root/.{bash,python}_history 2>/dev/null || :
   history -c 2>/dev/null || :
-  if has truncate; then
-    find /var/log -type f -exec sudo truncate -s 0 {} + 2>/dev/null || :
+  if has python3; then
+    find /var/log -type f -exec sudo python3 -c '
+import os, sys
+for f in sys.argv[1:]:
+    try:
+        fd = os.open(f, os.O_WRONLY | os.O_TRUNC | os.O_NOFOLLOW)
+        os.close(fd)
+    except Exception:
+        pass
+' {} + 2>/dev/null || :
   else
-    find /var/log -type f -exec sudo sh -c ':> "$1"' _ {} \; 2>/dev/null || :
+    find /var/log -type f -exec sudo sh -c 'for f in "$@"; do dd if=/dev/null of="$f" oflag=nofollow status=none 2>/dev/null || :; done' _ {} + 2>/dev/null || :
   fi
 }
 # Privacy & Security Hardening

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,13 @@
+🔒 Fix TOCTOU Symlink Attack in Log Truncation
+
+🎯 **What:**
+Fixed a Time-of-Check to Time-of-Use (TOCTOU) symlink vulnerability in `RaspberryPi/Scripts/pi-minify.sh` where `find` combined with `truncate` or bash `>` redirection was used to clear log files in `/var/log`.
+
+⚠️ **Risk:**
+If a subdirectory in `/var/log` is writable by a compromised service, an attacker could race the cleanup script by replacing a log file with a symlink pointing to a critical system file (like `/etc/shadow`) between the time `find` identifies the file and `truncate` executes. Since `truncate` and `>` follow symlinks, the script would run as root and inadvertently wipe the target system file.
+
+🛡️ **Solution:**
+Replaced the vulnerable truncation logic with robust alternatives that enforce symlink refusal at the system call level.
+- Used an inline Python script utilizing `os.open` with the `os.O_NOFOLLOW` flag to instantly fail (yielding `ELOOP`) if a file path component has been replaced by a symlink.
+- Provided a secure fallback using `dd oflag=nofollow` in case Python 3 is unavailable on the system.
+- Maintained the fast bulk-processing capabilities using `sys.argv[1:]` and `"$@"` alongside `find ... {} +`.


### PR DESCRIPTION
🎯 **What:**
Fixed a Time-of-Check to Time-of-Use (TOCTOU) symlink vulnerability in `RaspberryPi/Scripts/pi-minify.sh` where `find` combined with `truncate` or bash `>` redirection was used to clear log files in `/var/log`.

⚠️ **Risk:**
If a subdirectory in `/var/log` is writable by a compromised service, an attacker could race the cleanup script by replacing a log file with a symlink pointing to a critical system file (like `/etc/shadow`) between the time `find` identifies the file and `truncate` executes. Since `truncate` and `>` follow symlinks, the script would run as root and inadvertently wipe the target system file.

🛡️ **Solution:**
Replaced the vulnerable truncation logic with robust alternatives that enforce symlink refusal at the system call level.
- Used an inline Python script utilizing `os.open` with the `os.O_NOFOLLOW` flag to instantly fail (yielding `ELOOP`) if a file path component has been replaced by a symlink.
- Provided a secure fallback using `dd oflag=nofollow` in case Python 3 is unavailable on the system.
- Maintained fast bulk-processing capabilities using `sys.argv[1:]` and `"$@"` alongside `find ... {} +`.

---
*PR created automatically by Jules for task [18014793384506592886](https://jules.google.com/task/18014793384506592886) started by @Ven0m0*