### PR TITLE
🧹 remove unused mock imports in test_snap_mem_logic.py

### DIFF
--- a/Cachyos/Scripts/WIP/test_snap_mem_logic.py
+++ b/Cachyos/Scripts/WIP/test_snap_mem_logic.py
@@ -4,7 +4,6 @@ import unittest
 import sys
 import threading
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 # Dynamically import snap-mem.py
 file_path = Path(__file__).parent / "snap-mem.py"


### PR DESCRIPTION
🎯 **What:** Removed unused `MagicMock` and `patch` imports from `Cachyos/Scripts/WIP/test_snap_mem_logic.py`.
💡 **Why:** Removing dead code reduces noise, improves readability, and prevents potential linting errors.
✅ **Verification:** Ran the unit test script locally (all tests passed) and performed a `ruff` check.
✨ **Result:** A cleaner test file with no unnecessary dependencies.

---
*PR created automatically by Jules for task [903944702213200964](https://jules.google.com/task/903944702213200964) started by @Ven0m0*