### PR TITLE
chore: remove unused imports in python test scripts

### DIFF
--- a/Cachyos/Scripts/WIP/gh/test_git_fetch_mock.py
+++ b/Cachyos/Scripts/WIP/gh/test_git_fetch_mock.py
@@ -7,7 +7,7 @@ import unittest
 import sys
 import importlib.util
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 # Dynamically load git-fetch.py (hyphen in name prevents normal import)
 _file_path = Path(__file__).parent / "git-fetch.py"

--- a/Cachyos/Scripts/WIP/gphotos/verify_dup.py
+++ b/Cachyos/Scripts/WIP/gphotos/verify_dup.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 import unittest
-from pathlib import Path
 from Dup import find_duplicate_photos
 
 class TestDup(unittest.TestCase):

--- a/Cachyos/Scripts/WIP/test_snap_mem_logic.py
+++ b/Cachyos/Scripts/WIP/test_snap_mem_logic.py
@@ -4,7 +4,6 @@ import unittest
 import sys
 import threading
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 # Dynamically import snap-mem.py
 file_path = Path(__file__).parent / "snap-mem.py"


### PR DESCRIPTION
Addresses part of the "Dead Code Removal" focus area by safely removing explicitly unused imports identified by ruff.

---
*PR created automatically by Jules for task [7395369738050330157](https://jules.google.com/task/7395369738050330157) started by @Ven0m0*