### PR TITLE
🧹 Move local import sys to module level in Splitter.py

### DIFF
--- a/Cachyos/Scripts/WIP/gphotos/Splitter.py
+++ b/Cachyos/Scripts/WIP/gphotos/Splitter.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import argparse
+import sys
 
 
 # Function to calculate folder size recursively
@@ -140,7 +141,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if not os.path.isdir(args.photos_folder):
-        import sys
         print(f"Error: '{args.photos_folder}' is not a directory.", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
🎯 What: Moved the inline `import sys` statement from inside an `if` block at the bottom of the file to the module level at the top, alongside other standard library imports.
💡 Why: Standardizing imports at the module level improves readability and follows PEP 8 conventions. It ensures dependencies are clear from the beginning of the file.
✅ Verification: Ran `py_compile`, `ruff check`, and executed the unit tests in `test_splitter.py`. All tests passed, ensuring the change is syntactically valid and preserves existing functionality without side-effects.
✨ Result: `Cachyos/Scripts/WIP/gphotos/Splitter.py` now adheres strictly to PEP 8 import conventions, improving code maintainability.

---
*PR created automatically by Jules for task [3158955635406367150](https://jules.google.com/task/3158955635406367150) started by @Ven0m0*