### PR TITLE
🧹 Clean up stale KDE configuration TODO in setup.sh

### DIFF
--- a/Cachyos/setup.sh
+++ b/Cachyos/setup.sh
@@ -214,7 +214,7 @@ apply_konsave_profile() {
     konsave -i "$profile_file" || { warn "konsave import failed"; return 0; }
   fi
   konsave -a "$profile_name" || warn "konsave apply failed"
-  # TODO: kde config:
+  # KDE configuration:
   kwriteconfig6 --file kdeglobals --group QtQuickRendererSettings --key renderLoop threaded
   kwriteconfig6 --file kdeglobals --group QtQuickRendererSettings --key coreProfile true
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Replaced a stale `# TODO: kde config:` comment with a descriptive `# KDE configuration:` header in `Cachyos/setup.sh`.

💡 **Why:** How this improves maintainability
- The TODO was already addressed by the `kwriteconfig6` commands immediately following it. Removing stale TODOs reduces technical debt and improves code clarity.

✅ **Verification:** How you confirmed the change is safe
- Verified script syntax using `bash -n Cachyos/setup.sh`.
- Performed a code review which confirmed the change is purely structural and safe.

✨ **Result:** The improvement achieved
- Improved readability of the KDE configuration section by accurately reflecting that the configuration is implemented.

---
*PR created automatically by Jules for task [18010730286185524855](https://jules.google.com/task/18010730286185524855) started by @Ven0m0*