### PR TITLE
🔒 Fix command injection in xargs with bash -c

### DIFF
--- a/Cachyos/Scripts/Android/media-optimizer.sh
+++ b/Cachyos/Scripts/Android/media-optimizer.sh
@@ -496,9 +496,9 @@ process_directory() {
 
   if [[ ${#image_files[@]} -gt 0 ]]; then
     # Process using xargs for parallelization
-    printf '%s\0' "${image_files[@]}" | xargs -0 -P "$MEDIA_OPT_THREADS" -I{} bash -c '
+    printf '%s\0' "${image_files[@]}" | xargs -0 -P "$MEDIA_OPT_THREADS" -n 1 bash -c '
       source "$0"
-      process_image "{}"
+      process_image "$1"
     ' "$0"
 
     # Run deduplication if enabled


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `Cachyos/Scripts/Android/media-optimizer.sh`.
⚠️ **Risk:** Files with malicious names (e.g., containing `$(command)`) could execute arbitrary code when processed by the script's parallel image optimization logic.
🛡️ **Solution:** Switched from `xargs -I{}` interpolation to `xargs -n 1` and passed the filename as a positional parameter (`$1`) to the `bash -c` subshell.

---
*PR created automatically by Jules for task [2403800777248129864](https://jules.google.com/task/2403800777248129864) started by @Ven0m0*