### PR TITLE
🧪 [testing improvement] Add error path tests for detect_encoding in combine.py

### DIFF
--- a/RaspberryPi/Scripts/test_combine.py
+++ b/RaspberryPi/Scripts/test_combine.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+from pathlib import Path
+import importlib.util
+
+# Import combine.py using importlib
+path = Path(__file__).parent / "combine.py"
+spec = importlib.util.spec_from_file_location("combine", path)
+combine = importlib.util.module_from_spec(spec)
+sys.modules["combine"] = combine
+spec.loader.exec_module(combine)
+
+class TestCombine(unittest.TestCase):
+    def test_detect_encoding_no_chardet(self):
+        """Test fallback to utf-8 when chardet is not available."""
+        with patch("combine.chardet", None):
+            self.assertEqual(combine.detect_encoding(b"test"), "utf-8")
+
+    def test_detect_encoding_with_chardet_success(self):
+        """Test that encoding from chardet is used when available."""
+        mock_chardet = MagicMock()
+        mock_chardet.detect.return_value = {"encoding": "shift_jis"}
+        with patch("combine.chardet", mock_chardet):
+            self.assertEqual(combine.detect_encoding(b"test"), "shift_jis")
+
+    def test_detect_encoding_with_chardet_none_result(self):
+        """Test fallback to utf-8 when chardet returns None for encoding."""
+        mock_chardet = MagicMock()
+        mock_chardet.detect.return_value = {"encoding": None}
+        with patch("combine.chardet", mock_chardet):
+            self.assertEqual(combine.detect_encoding(b"test"), "utf-8")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses a testing gap in `RaspberryPi/Scripts/combine.py` by implementing unit tests for the `detect_encoding` function.

🎯 **What:** The testing gap addressed is the lack of coverage for the fallback logic and error paths in `detect_encoding`.
📊 **Coverage:** The following scenarios are now tested:
- Environment where `chardet` is not available.
- `chardet` returns `None` for encoding.
- `chardet` successfully detects an encoding.
✨ **Result:** Improved reliability of encoding detection logic and ensured fallback to UTF-8 works as expected.

---
*PR created automatically by Jules for task [16703043991518026794](https://jules.google.com/task/16703043991518026794) started by @Ven0m0*